### PR TITLE
atlas integrated into run.py and settings.yaml; pre- and post-processor updated

### DIFF
--- a/pilates/atlas/postprocessor.py
+++ b/pilates/atlas/postprocessor.py
@@ -6,26 +6,15 @@ import os
 import logging
 
 # Commented commands for only for debugging
-import yaml
-import argparse
-with open('settings.yaml') as file:
-    settings = yaml.load(file, Loader=yaml.FullLoader)
-
-h5fname =  'custom_mpo_48197301_model_data.h5' # 'custom_mpo_06197001_model_data.h5'  #
-year = 2010
+# import yaml
+# import argparse
+# with open('settings.yaml') as file:
+#     settings = yaml.load(file, Loader=yaml.FullLoader)
 
 
 logger = logging.getLogger(__name__)
 
 
-
-
-# update "cars" and "hh_cars" columns in urbansim h5 outputs
-# now this update is in-situ to minimize code changes needed
-
-warm_start = True
-
-    
 def atlas_update_h5_vehicle(settings, year, warm_start=False):
     # use atlas outputs in year provided and update "cars" & "hh_cars"
     # columns in urbansim h5 files
@@ -49,6 +38,7 @@ def atlas_update_h5_vehicle(settings, year, warm_start=False):
 
     # read original h5 files
     with pd.HDFStore(os.path.join(h5path, h5fname), mode='r+') as h5:
+
         # if in main loop, update "model_data_*.h5", which has three layers ({$year}/households/cars)
         if not warm_start:
             olddf = h5[str(year)]['households']['cars']

--- a/pilates/atlas/postprocessor.py
+++ b/pilates/atlas/postprocessor.py
@@ -1,9 +1,90 @@
+import h5py
+import numpy as np
 import pandas as pd
+from pandas import HDFStore
 import os
+import logging
 
-def atlas_postprocessor():
-    ## if needed, any post process can be done.
-    ## or move output result to place usable by next step... 
-    ## may not really need this
-    print( "atlas_postprocessor section, nothing to do at this time.  ending." )
-    return
+# Commented commands for only for debugging
+import yaml
+import argparse
+with open('settings.yaml') as file:
+    settings = yaml.load(file, Loader=yaml.FullLoader)
+
+h5fname =  'custom_mpo_48197301_model_data.h5' # 'custom_mpo_06197001_model_data.h5'  #
+year = 2010
+
+
+logger = logging.getLogger(__name__)
+
+
+
+
+# update "cars" and "hh_cars" columns in urbansim h5 outputs
+# now this update is in-situ to minimize code changes needed
+
+warm_start = True
+
+    
+def atlas_update_h5_vehicle(settings, year, warm_start=False):
+    # use atlas outputs in year provided and update "cars" & "hh_cars"
+    # columns in urbansim h5 files
+    logger.info('ATLAS is updating urbansim outputs for Year {}'.format(year))
+
+    # read and format atlas vehicle ownership output
+    atlas_output_path = settings['atlas_host_output_folder'] # 'pilates/atlas/atlas_output'  #
+    fname = 'householdv_{}.csv'.format(year)
+    df = pd.read_csv(os.path.join(atlas_output_path, fname))
+    df = df.rename(columns={'nvehicles':'cars'}).set_index('household_id')['cars'].sort_index(ascending=True)
+    df_hh = pd.cut(df, bins=[-0.5, 0.5, 1.5, np.inf], labels=['none', 'one', 'two or more'])
+
+    # set which h5 file to update
+    h5path = settings['usim_local_data_folder']
+    if warm_start:
+        region = settings['region']
+        region_id = settings['region_to_region_id'][region]
+        h5fname = 'custom_mpo_{}_model_data.h5'.format(region_id)
+    else:
+        h5fname = 'model_data_{}.h5'.format(year)
+
+    # read original h5 files
+    with pd.HDFStore(os.path.join(h5path, h5fname), mode='r+') as h5:
+        # if in main loop, update "model_data_*.h5", which has three layers ({$year}/households/cars)
+        if not warm_start:
+            olddf = h5[str(year)]['households']['cars']
+            h5[str(year)]['households']['cars'] = df
+            h5[str(year)]['households']['hh_cars'] = df_hh
+            if olddf.shape != df.shape:
+                logger.error('household_id mismatch found when ATLAS updates h5 vehicle info')
+        
+        # if in warm start, update "custom_mpo_***.h5", which has two layers (households/cars)
+        else:
+            olddf = h5['households']['cars']
+            h5['households']['cars'] = df
+            h5['households']['hh_cars'] = df_hh
+            if olddf.shape != df.shape:
+                logger.error('household_id mismatch found when ATLAS updates h5 vehicle info')
+
+
+
+
+
+def atlas_add_vehileTypeId(settings, year, warm_start=False):
+    # add a "vehicleTypeId" column in atlas output vehicles_{$year}.csv,
+    # which will be read by beam preprocessor
+    # vehicleTypeId = conc "bodytype"-"vintage_category"-"pred_power"
+
+    atlas_output_path = settings['atlas_host_output_folder']
+    fname = 'vehicles_{}.csv'.format(year)
+
+    # read original atlas output "vehicles_*.csv" as dataframe
+    df = pd.read_csv(os.path.join(atlas_output_path, fname))
+
+    # add "vehicleTypeId" column in dataframe
+    df['vehicleTypeId']=df[['bodytype', 'vintage_category', 'pred_power']].agg('-'.join, axis=1)
+
+    # overwrite the original csv file
+    df.to_csv(os.path.join(atlas_output_path, fname), index=False)
+
+
+        

--- a/pilates/atlas/postprocessor.py
+++ b/pilates/atlas/postprocessor.py
@@ -72,7 +72,7 @@ def atlas_update_h5_vehicle(settings, year, warm_start=False):
 
 
 
-def atlas_add_vehileTypeId(settings, year, warm_start=False):
+def atlas_add_vehileTypeId(settings, year):
     # add a "vehicleTypeId" column in atlas output vehicles_{$year}.csv,
     # which will be read by beam preprocessor
     # vehicleTypeId = conc "bodytype"-"vintage_category"-"pred_power"

--- a/pilates/atlas/preprocessor.py
+++ b/pilates/atlas/preprocessor.py
@@ -8,21 +8,23 @@ import logging
 
 # import yaml
 # import argparse
-# def parse_args_and_settings(settings_file='settings.yaml'):
-
-#     # read settings from config file
-#     with open(settings_file) as file:
-#         settings = yaml.load(file, Loader=yaml.FullLoader)
-#     return settings
-# settings = parse_args_and_settings()
-
+# with open('settings.yaml') as file:
+#     settings = yaml.load(file, Loader=yaml.FullLoader)
 
 logger = logging.getLogger(__name__)
 
-def prepare_atlas_inputs(settings, year):
+
+def prepare_atlas_inputs(settings, year, warm_start=False):
     # set where to find urbansim output 
     urbansim_output_path = settings['usim_local_data_folder']
-    urbansim_output_fname = 'model_data_{}.h5'.format(year)
+    if warm_start:
+        # if warm start, read custom_mpo h5
+        region = settings['region']
+        region_id = settings['region_to_region_id'][region]
+        urbansim_output_fname = 'custom_mpo_{}_model_data.h5'.format(region_id)
+    else:
+        # if in main loop, read urbansim-generated h5 
+        urbansim_output_fname = 'model_data_{}.h5'.format(year)
     urbansim_output = os.path.join(urbansim_output_path,urbansim_output_fname)
     
     # set where to put atlas csv inputs (processed from urbansim outputs)
@@ -35,27 +37,30 @@ def prepare_atlas_inputs(settings, year):
     
     # read urbansim h5 outputs
     with pd.HDFStore(urbansim_output,mode='r') as data:
+        if not warm_start:
+            data = data['/{}'.format(year)]
+
         try:
             # prepare households atlas input
-            households = data['{}/households'.format(year)]
+            households = data['/households']
             households.to_csv('{}/households.csv'.format(atlas_input_path))
 
             # prepare blocks atlas input
-            blocks = data['{}/blocks'.format(year)]
+            blocks = data['/blocks']
             blocks.to_csv('{}/blocks.csv'.format(atlas_input_path))          
 
             # prepare persons atlas input
-            persons = data['{}/persons'.format(year)]
+            persons = data['/persons']
             persons.to_csv('{}/persons.csv'.format(atlas_input_path))
 
             # prepare residential unit atlas input
-            residential_units = data['{}/residential_units'.format(year)]
+            residential_units = data['/residential_units']
             residential_units.to_csv('{}/residential.csv'.format(atlas_input_path))
 
             # prepare jobs atlas input
-            jobs = data['{}/jobs'.format(year)]
+            jobs = data['/jobs']
             jobs.to_csv('{}/jobs.csv'.format(atlas_input_path))
 
         except: 
-            logger.info('Urbansim Year {} Output Was Not Loaded Correctly by ATLAS')
+            logger.error('Urbansim Year {} Output Was Not Loaded Correctly by ATLAS')
 

--- a/pilates/atlas/preprocessor.py
+++ b/pilates/atlas/preprocessor.py
@@ -31,7 +31,7 @@ def prepare_atlas_inputs(settings, year):
     # if atlas input path does not exist, create one
     if not os.path.exists(atlas_input_path):
         os.makedirs(atlas_input_path)
-        print('ATLAS Input Path Created for Year {}'.format(year))
+        logger.info('ATLAS Input Path Created for Year {}'.format(year))
     
     # read urbansim h5 outputs
     with pd.HDFStore(urbansim_output,mode='r') as data:
@@ -57,5 +57,5 @@ def prepare_atlas_inputs(settings, year):
             jobs.to_csv('{}/jobs.csv'.format(atlas_input_path))
 
         except: 
-            print('Urbansim Year {} Output Was Not Loaded Correctly by ATLAS')
+            logger.info('Urbansim Year {} Output Was Not Loaded Correctly by ATLAS')
 

--- a/run.py
+++ b/run.py
@@ -182,11 +182,11 @@ def get_atlas_docker_vols(settings):
     return atlas_docker_vols
 
 ## For Atlas container command
-def get_atlas_cmd(settings, freq, output_year):
+def get_atlas_cmd(settings, freq, output_year, npe, nsample):
     basedir = settings.get('basedir','/')
     codedir = settings.get('codedir','/')
     formattable_atlas_cmd = settings['atlas_formattable_command']
-    atlas_cmd = formattable_atlas_cmd.format(freq, forecast_year, basedir, codedir)
+    atlas_cmd = formattable_atlas_cmd.format(freq, forecast_year, npe, nsample, basedir, codedir)
     return atlas_cmd
 
 
@@ -317,9 +317,11 @@ def run_atlas(settings, output_year, client, warm_start_atlas):
     image_names = settings['docker_images']
     vehicle_ownership_model = settings.get('vehicle_ownership_model',False)
     freq = settings.get('vehicle_ownership_freq', False)
+    npe = settings.get('atlas_num_processes', False)
+    nsample = settings.get('atlas_sample_size', False)
     atlas_image = image_names[vehicle_ownership_model]  ## ie atlas
     atlas_docker_vols = get_atlas_docker_vols(settings)
-    atlas_cmd = get_atlas_cmd(settings, freq, output_year)
+    atlas_cmd = get_atlas_cmd(settings, freq, output_year, npe, nsample)
     docker_stdout = settings.get('docker_stdout', False)
 
 
@@ -338,8 +340,8 @@ def run_atlas(settings, output_year, client, warm_start_atlas):
     # 3. RUN ATLAS via docker container client
     print_str = (
         "Simulating vehicle ownership for {0} "
-        "with frequency {1}.".format(
-            output_year, freq ))
+        "with frequency {1}, npe {2} nsample {3}".format(
+            output_year, freq, npe, nsample))
     formatted_print(print_str)
     atlas = client.containers.run(
         atlas_image,

--- a/run.py
+++ b/run.py
@@ -326,7 +326,8 @@ def run_atlas(settings, freq, output_year, client):
     print_str = (
         "Preparing input data for vehicle ownership simulation for {0}.".format(output_year) )
     formatted_print(print_str)
-    ## ++ may need to move/copy data into the right folder?
+    # prepare atlas csv inputs from urbansim h5 output
+    # preprocessed csv input files saved in "atlas/atlas_inputs/year{}/"
     atlas_pre.prepare_atlas_inputs(settings, year)
 
     # 3. RUN ATLAS via docker container client

--- a/settings.yaml
+++ b/settings.yaml
@@ -63,13 +63,10 @@ atlas_container_input_folder: /atlas_input
 atlas_container_output_folder: /atlas_output
 atlas_basedir: /
 atlas_codedir: /
-# atlas_outyear: 2017      # YW: comment out; main loop in run.py will pass "year" to run_atlas
-# atlas_freq:    1         # Yw: comment out; added a vehicle_ownership_freq at beginning
 atlas_sample_size: 0     # zero means no sampling, whole pop.
 atlas_num_processes: 94  # can't you just detect num of cpu?
-atlas_formattable_command: "--freq {0} --outyear {1} --basedir {2} --codedir {3}" 
-## command line options to main.R may need to be updated to handle additional params:
-## --size {4} --proc {5} 
+atlas_formattable_command: "--freq {0} --outyear {1} --npe {2} --nsample {3} --basedir {4} --codedir {5}"
+
 
 
 # BEAM 

--- a/settings.yaml
+++ b/settings.yaml
@@ -5,18 +5,19 @@
 ############################
 
 # scenario defs
-region: austin
+region: sfbay
 scenario: base
-start_year: 2010      ## atlas can use this? 
-end_year: 2013
+start_year: 2010  
+end_year: 2012
 land_use_freq: 1
-travel_model_freq: 1  ## atlas can use this?
+travel_model_freq: 1  
+vehicle_ownership_freq: 1 
 
 # simulation platforms (comment out to turn off)
-##land_use_model: urbansim
-##travel_model: beam
-##activity_demand_model: activitysim
-vehicle_ownership_model: atlas           ##
+land_use_model: urbansim
+travel_model: beam
+activity_demand_model: activitysim
+vehicle_ownership_model: atlas  
 
 # docker settings
 docker_images:
@@ -30,8 +31,8 @@ docker_stdout: True           ## change this to True to get regular container st
 pull_latest: False
 
 # skim settings
-skims_zone_type: block_group  # one of [taz, block_group, block]
-skims_fname: austin-skims-res-full-new.csv.gz
+skims_zone_type: taz  # one of [taz, block_group, block]
+skims_fname: as-base-skims-sfbay-taz.csv.gz
 
 # region_zone_type:
 #   austin: block_groups # one of [taz, block_groups, block]
@@ -54,7 +55,7 @@ usim_formattable_input_file_name: "custom_mpo_{region_id}_model_data.h5"
 usim_formattable_output_file_name: "model_data_{year}.h5"
 usim_formattable_command: "-r {0} -i {1} -y {2} -f {3} -t {4}"
 
-## ATLAS: vsim, vehicle simulation - Ling/Tin/Yuhan 
+## ATLAS: vehicle simulation (may call usim somewhere) - Ling/Tin/Yuhan 
 ## Docker bind mounts: host == local; container == remote == client
 atlas_host_input_folder: pilates/atlas/atlas_input  
 atlas_host_output_folder: pilates/atlas/atlas_output
@@ -62,11 +63,11 @@ atlas_container_input_folder: /atlas_input
 atlas_container_output_folder: /atlas_output
 atlas_basedir: /
 atlas_codedir: /
-atlas_outyear: 2017      ## maybe can use  start_year ??
-atlas_freq:    1         ## travel_model_freq ??
+# atlas_outyear: 2017      # YW: comment out; main loop in run.py will pass "year" to run_atlas
+# atlas_freq:    1         # Yw: comment out; added a vehicle_ownership_freq at beginning
 atlas_sample_size: 0     # zero means no sampling, whole pop.
 atlas_num_processes: 94  # can't you just detect num of cpu?
-vsim_formattable_command: "--freq {0} --outyear {1} --basedir {2} --codedir {3}" 
+atlas_formattable_command: "--freq {0} --outyear {1} --basedir {2} --codedir {3}" 
 ## command line options to main.R may need to be updated to handle additional params:
 ## --size {4} --proc {5} 
 


### PR DESCRIPTION
The main function to call in run.py is "run_atlas(settings, output_year, client, warm_start_atlas)", which can be used for both warm start sequence and main loop; all "vsim" renamed back to "atlas"; post- and pre-processors updated to be versatile (when warm_start_atlas turned on/off); settings.yaml and run.py updated accordingly. 